### PR TITLE
Fix loop address for RLE records

### DIFF
--- a/ips.py
+++ b/ips.py
@@ -110,7 +110,7 @@ def applyPatch(originalFile, patchFile, newFile):
                 os.write(new.fileno(), bytes([patch[a+7]]))
             
             #update loop address
-            a += 6 + times
+            a += 8
 
     new.close()
     return (False, 'Patch hadn\'t an EOF flag.')


### PR DESCRIPTION
The last part of the RLE record is always a single byte to be written the specified number of times, but the code erroneously advanced its pointer to the bytes in the patch by the number times the single byte was written. This pull request restores the correct behavior.